### PR TITLE
Add timeout to bluetoothctl check to prevent CI hang

### DIFF
--- a/roles/desktop/tasks/i3.yml
+++ b/roles/desktop/tasks/i3.yml
@@ -72,7 +72,7 @@
   when: desktop_ibm_managed
 
 - name: Check for Bluetooth device
-  ansible.builtin.shell: "timeout 5 bluetoothctl list | grep -oE '([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}'"
+  ansible.builtin.shell: set -o pipefail && timeout 5 bluetoothctl list | grep -oE '([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}'
   register: desktop_bluetooth_devices
   failed_when: false
   changed_when: false

--- a/roles/desktop/tasks/i3.yml
+++ b/roles/desktop/tasks/i3.yml
@@ -72,9 +72,9 @@
   when: desktop_ibm_managed
 
 - name: Check for Bluetooth device
-  ansible.builtin.shell: "bluetoothctl list | grep -oE '([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}'"
+  ansible.builtin.shell: "timeout 5 bluetoothctl list | grep -oE '([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}'"
   register: desktop_bluetooth_devices
-  ignore_errors: true
+  failed_when: false
   changed_when: false
 
 - name: Register bluetooth support


### PR DESCRIPTION
## Summary

- Wraps `bluetoothctl list` with `timeout 5` so the CI desktop role on Fedora 43 can't hang indefinitely when `bluez` is installed but `bluetoothd` cannot start (no hardware in the container).
- Switches `ignore_errors: true` → `failed_when: false`, which is necessary because `ignore_errors` only catches non-zero exits, not infinite blocking — and renders more cleanly in the playbook output.

`desktop_bluetooth_devices.stdout` will be empty on timeout, which the next task (`Register bluetooth support`) already treats as "no bluetooth support", so semantics are preserved.

## Why

The `desktop (Fedora 43)` job has been hanging in CI (e.g. PR #4, PR #5). PR #5 removes the Signal flatpak install entirely and is still hanging, which means the hang is upstream of `signal.yml` in the desktop role. The most plausible candidate at that point in the task order is the bluetoothctl check, since `bluez` is installed in the dnf step just above it, D-Bus tries to activate `bluetooth.service`, and `bluetoothctl list` can block waiting for the daemon's D-Bus name to appear rather than failing fast. Behavior likely differs between F42's and F43's bluez/systemd combo.

## Test plan

- [ ] CI passes on `desktop (Fedora 43)` in a reasonable amount of time
- [ ] CI still passes on `desktop (Fedora 42)`
- [ ] CI still passes on `headless (Fedora 42)` and `headless (Fedora 43)`

https://claude.ai/code/session_01D7LfRWuFEbNFoLTLBkQhXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7LfRWuFEbNFoLTLBkQhXQ)_