### PR TITLE
Pass GITHUB_TOKEN to ansible to avoid api.github.com rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run headless playbook in container
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           container_id=$(docker run --detach --privileged \
             --cgroupns=host \
@@ -84,7 +86,9 @@ jobs:
             done
             exit "$bootstrap_status"
           fi
-          docker exec --tty "$container_id" env TERM=xterm \
+          docker exec --tty "$container_id" \
+            --env "GITHUB_TOKEN=$GITHUB_TOKEN" \
+            env TERM=xterm \
             ANSIBLE_FORCE_COLOR=0 ANSIBLE_DIFF_ALWAYS=0 ANSIBLE_STDOUT_CALLBACK=default \
             ansible-playbook /etc/ansible/headless.yml 2>&1 | tee /tmp/play.log
           status=${PIPESTATUS[0]}
@@ -115,6 +119,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run desktop playbook in container
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           container_id=$(docker run --detach --privileged \
             --cgroupns=host \
@@ -136,7 +142,9 @@ jobs:
             done
             exit "$bootstrap_status"
           fi
-          docker exec --tty "$container_id" env TERM=xterm \
+          docker exec --tty "$container_id" \
+            --env "GITHUB_TOKEN=$GITHUB_TOKEN" \
+            env TERM=xterm \
             ANSIBLE_FORCE_COLOR=0 ANSIBLE_DIFF_ALWAYS=0 ANSIBLE_STDOUT_CALLBACK=default \
             ansible-playbook /etc/ansible/desktop.yml 2>&1 | tee /tmp/play.log
           status=${PIPESTATUS[0]}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,8 @@ jobs:
             done
             exit "$bootstrap_status"
           fi
-          docker exec --tty "$container_id" \
-            --env "GITHUB_TOKEN=$GITHUB_TOKEN" \
-            env TERM=xterm \
+          docker exec --tty "$container_id" env TERM=xterm \
+            GITHUB_TOKEN="$GITHUB_TOKEN" \
             ANSIBLE_FORCE_COLOR=0 ANSIBLE_DIFF_ALWAYS=0 ANSIBLE_STDOUT_CALLBACK=default \
             ansible-playbook /etc/ansible/headless.yml 2>&1 | tee /tmp/play.log
           status=${PIPESTATUS[0]}
@@ -142,9 +141,8 @@ jobs:
             done
             exit "$bootstrap_status"
           fi
-          docker exec --tty "$container_id" \
-            --env "GITHUB_TOKEN=$GITHUB_TOKEN" \
-            env TERM=xterm \
+          docker exec --tty "$container_id" env TERM=xterm \
+            GITHUB_TOKEN="$GITHUB_TOKEN" \
             ANSIBLE_FORCE_COLOR=0 ANSIBLE_DIFF_ALWAYS=0 ANSIBLE_STDOUT_CALLBACK=default \
             ansible-playbook /etc/ansible/desktop.yml 2>&1 | tee /tmp/play.log
           status=${PIPESTATUS[0]}

--- a/roles/headless/tasks/github-release.yml
+++ b/roles/headless/tasks/github-release.yml
@@ -4,6 +4,7 @@
     user: "{{ github_release_user }}"
     repo: "{{ github_release_binary }}"
     action: latest_release
+    token: "{{ lookup('env', 'GITHUB_TOKEN') | default(omit, true) }}"
   register: headless_github_release
 
 - name: Install from github {{ github_release_binary }}


### PR DESCRIPTION
## Summary

- Forwards the workflow-provided `GITHUB_TOKEN` through `docker exec` into the playbook container.
- Adds `token: "{{ lookup('env', 'GITHUB_TOKEN') | default(omit, true) }}"` to the `community.general.github_release` task — the token is **omitted** when the env var is unset or empty, so local runs without a token continue to work (subject to the unauthenticated rate limit).

## Why

PR #6 hit a spurious `headless (Fedora 42)` failure with a 403 from `api.github.com`:

> API rate limit exceeded for 40.65.56.224.

`roles/headless/tasks/github-release.yml` calls `community.general.github_release` three times (for `find-replace`, `txt`, `connectivity`) to discover latest release tags. Unauthenticated requests share a 60/hr quota per IP, and GitHub Actions runners pool IPs across many users — so the limit is hit intermittently in CI. Authenticated requests get a much higher quota (5000/hr).

## Test plan

- [ ] `headless (Fedora 42)` and `headless (Fedora 43)` pass in CI without 403s
- [ ] `desktop` jobs pass (same code path runs in desktop via the headless role)
- [ ] Local `ansible-playbook headless.yml` runs continue to work without `GITHUB_TOKEN` set (token is omitted)

https://claude.ai/code/session_01D7LfRWuFEbNFoLTLBkQhXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7LfRWuFEbNFoLTLBkQhXQ)_