### PR TITLE
Bump actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run ansible-lint
         uses: ansible/ansible-lint@v25
@@ -60,7 +60,7 @@ jobs:
         fedora: ${{ fromJson(needs.fedora-versions.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run headless playbook in container
         env:
@@ -115,7 +115,7 @@ jobs:
         fedora: ${{ fromJson(needs.fedora-versions.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run desktop playbook in container
         env:


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` from v4 to v6 across the three workflow steps (Lint, headless, desktop).

v6 is the current latest major version per the release page.

## Test plan

- [x] CI passes on all jobs

https://claude.ai/code/session_01D7LfRWuFEbNFoLTLBkQhXQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7LfRWuFEbNFoLTLBkQhXQ)_